### PR TITLE
Don't fast-forward

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,7 +65,7 @@ then
 fi
 
 # Merge all shas together into one commit.
-git merge --no-commit "${shas[@]}"
+git merge --no-ff --no-commit "${shas[@]}"
 git commit --message "Merged Pull Requests (${shas[*]})"
 
 echo "Merged ${#shas[@]} pull requests"


### PR DESCRIPTION
Don't allow git merge to fast-forward, otherwise there might be nothing to commit.